### PR TITLE
Set namespace for kubeshell session

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Interactive kubectl shell written in bash.
 | Flag | Short | Description |
 | ---- | ----- | ----------- |
 | `--help` | `-h` | Display the help message |
+| `--namespace` | `-n` or `-ns` | Set a namespace for the session |
 
 ## Example of usage
 

--- a/kubeshell
+++ b/kubeshell
@@ -40,11 +40,20 @@ function interactive_loop() {
 
 function parse_args() {
 	while [[ $# -gt 0 ]]; do
+
 		key="$1"
+
 		case $key in
 			-h|--help)
 				show_kubeshell_help
 				exit 0
+				;;
+			-n|-ns|--namespace)
+				local NAMESPACE="$2"
+				echo "> Setting namespace/$NAMESPACE"
+				kubectl config set-context --current --namespace="$NAMESPACE"
+				shift
+				shift
 				;;
 			*)
 				# Ignore unknown argument

--- a/kubeshell
+++ b/kubeshell
@@ -28,6 +28,7 @@ function show_kubeshell_help() {
 	echo -e
 	echo -e "Available flags:"
 	echo -e "  -h, --help\t\tDisplay this help"
+	echo -e "  -n,-ns, --namespace\tSet a namespace to use during the kubeshell session"
 }
 
 function backup_current_namespace() {

--- a/kubeshell
+++ b/kubeshell
@@ -6,8 +6,16 @@ stty -echoctl # Hide ^C
 
 trap quit_kubeshell SIGINT
 
+NAMESPACE_BKP=""
+
 function quit_kubeshell() {
 	echo -e "\rExiting kubeshell..."
+
+	# Restoring initial namespace
+	if [[ "$NAMESPACE_BKP" != "" ]]; then
+		kubectl config set-context --current --namespace="$NAMESPACE_BKP"
+	fi
+
 	exit 0
 }
 
@@ -20,6 +28,10 @@ function show_kubeshell_help() {
 	echo -e
 	echo -e "Available flags:"
 	echo -e "  -h, --help\t\tDisplay this help"
+}
+
+function backup_current_namespace() {
+	NAMESPACE_BKP="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
 }
 
 function interactive_loop() {
@@ -49,6 +61,7 @@ function parse_args() {
 				exit 0
 				;;
 			-n|-ns|--namespace)
+				backup_current_namespace
 				local NAMESPACE="$2"
 				echo "> Setting namespace/$NAMESPACE"
 				kubectl config set-context --current --namespace="$NAMESPACE"


### PR DESCRIPTION
## Problem
To change namespace, you had to use the extended command (`config set-context --current --namespace=NAMESPACE`)

## Solution
Use a flag (-n, -ns or --namespace) to set the namespace used for the kubeshell session

e.g.: `kubeshell -n kube-system`
